### PR TITLE
restructure release notes

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -24,11 +24,12 @@
     * [Offline Maps](SettingsView/OfflineMaps.md)
     * [Virtual Joystick (PX4)](SettingsView/VirtualJoystick.md)
 * [Releases](releases/README.md)
-    * [Release Notes](releases/stable_v3.2_short.md)
+    * [Release Notes](releases/release_notes.md)
+       * [v3.2 (Detailed)](releases/stable_v3.2_long.md)
     * [Daily Builds](releases/daily_builds.md)
     * [Daily Build New Features](releases/daily_build_new_features.md)
     * [Google Play Privacy Policy](releases/google_play_privacy_policy.md)
-    * [Previous Release Notes](releases/previous_release_notes.md)
+
 * [Support](Support/Support.md)
 
 

--- a/en/SetupView/Joystick.md
+++ b/en/SetupView/Joystick.md
@@ -12,7 +12,7 @@
 
 To enable Joystick support in PX4 you need to set the parameter `COM_RC_IN_MODE` to 1 - *Joystick/No RC Checks*. If this parameter is not set then *Joystick* will not be offered as a setup option.
 
-This is enabled by default for PX4 SITL builds (see the [Parameters](..SetupView/Parameters.md) topic for information on how to find and set a particular parameter). 
+This is enabled by default for PX4 SITL builds (see the [Parameters](../SetupView/Parameters.md) topic for information on how to find and set a particular parameter). 
 
 <!-- what is "Virtual RC by Joystick"? -->
 

--- a/en/releases/previous_release_notes.md
+++ b/en/releases/previous_release_notes.md
@@ -1,3 +1,0 @@
-# Release Notes - Old stable builds
-
-* [Version 3.1](releases/stable_v3.1_short.md)

--- a/en/releases/release_notes.md
+++ b/en/releases/release_notes.md
@@ -1,22 +1,6 @@
 # Release Notes
 
-## Stable Version 3.1
+{% include "./stable_v3.2_short.md" %}
 
-New Features
 
-* [Survey](../PlanView/Survey.md) mission support
-* [GeoFence](../PlanView/PlanGeoFence.md) Support in Plan View
-* [Rally Point](../PlanView/PlanRallyPoints.md) support in Plan View (ArduPilot only)
-* ArduPilot onboard compass calibration
-* Parameter editor search will now search as you type for quicker access
-* Parameter display now supports unit conversion
-* GeoTag images from log files (PX4 only)
-* System health in instrument panel
-* Mavlink 2.0 support (no signing yet)
-
-Major Bug Fixes
-
-* Fixed crash after disconnect from Vehicle
-* Fixed android crash when using SiK Radios
-* Many multi-vehicle fixes
-* Bluetooth fixes
+{% include "./stable_v3.1_short.md" %}

--- a/en/releases/stable_v3.1_short.md
+++ b/en/releases/stable_v3.1_short.md
@@ -1,18 +1,16 @@
-# Release Notes
-
 ## Stable Version 3.1
 
 New Features
 
 * [Survey](../PlanView/Survey.md) mission support
-* [GeoFence](../PlanView/PlanGeoFence.md) Support in Plan View
+* [GeoFence](../PlanView/PlanGeoFence.md) support in Plan View
 * [Rally Point](../PlanView/PlanRallyPoints.md) support in Plan View (ArduPilot only)
 * ArduPilot onboard compass calibration
 * Parameter editor search will now search as you type for quicker access
 * Parameter display now supports unit conversion
 * GeoTag images from log files (PX4 only)
 * System health in instrument panel
-* Mavlink 2.0 support (no signing yet)
+* MAVLink 2.0 support (no signing yet)
 
 Major Bug Fixes
 

--- a/en/releases/stable_v3.2_long.md
+++ b/en/releases/stable_v3.2_long.md
@@ -1,4 +1,4 @@
-# Release Notes (detailed) - Version 3.2
+# QGroundControl v3.2 Release Notes (Detailed)
 
 This topic contains a high level and *non-exhaustive* list of new features added to *QGroundControl* in version 3.2.
 

--- a/en/releases/stable_v3.2_short.md
+++ b/en/releases/stable_v3.2_short.md
@@ -1,11 +1,11 @@
-# Release Notes - Version 3.2
+## Stable Version 3.2 (Current)
 
-This topic contains a high level and *non-exhaustive* list of new features added to *QGroundControl* in version 3.2. More detailed release notes can be found [here](stable_v3.2_long.md).
+This topic contains a high level and *non-exhaustive* list of new features added to *QGroundControl* in version 3.2. More detailed release notes can be found [here](../releases/stable_v3.2_long.md).
 
 * **Settings**
-	* ***File Save path*** - Specify a save path for all files used by QGC.
+	* **File Save path** - Specify a save path for all files used by QGC.
 	* **Telemetry log auto-save** - Telemetry logs are now automatically saved without prompting.
-	* ***AutoLoad Plans*** - Used to automaticaclly load a Plan onto a vehicle when it first connects.
+	* **AutoLoad Plans** - Used to automatically load a Plan onto a vehicle when it first connects.
 	* **RTK GPS** - Specify the Survey in accuracy and Minimum observation duration.
 
 * **Setup**


### PR DESCRIPTION
Restructures release notes so that "short version notes" all the current releases are in the release notes page. The detailed version is a sub page. This is simpler to navigate.

@DonLakeFlyer I have kept the short release notes page separate in case you hate this structure. If you're OK with this structure I'll move their content into the release note page (rather than including it) and delete those pages. 

I'll merge this now, because it fixes a number of broken links.

