### PR TITLE
Move troubleshooting topics into Common Problems

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -57,6 +57,8 @@
     * [Common Problems](Support/CommonProblems.md)
        * [Parameter Download failures](Support/ParameterDownload.md)
        * [Plan Upload/Download failures](Support/PlanUploadDownload.md)
+       * [Audio Problems](Support/audio_problems.md)
+       * [Video Driver/UI Rendering](Support/ui_driver_problems.md)
 
 ## Flight Stacks
 

--- a/en/Support/CommonProblems.md
+++ b/en/Support/CommonProblems.md
@@ -2,3 +2,5 @@
 
 * [Parameter Download failures](../Support/ParameterDownload.md)
 * [Plan Upload/Download failures](../Support/PlanUploadDownload.md)
+* [Audio Problems](../Support/audio_problems.md)
+* [Video Driver/UI Rendering Problems](../Support/ui_driver_problems.md)

--- a/en/Support/Support.md
+++ b/en/Support/Support.md
@@ -62,29 +62,12 @@ If Windows is telling you the *QGroundControl program is unresponsive* use the f
 
 ## Troubleshooting
 
-### 64-bit Windows: Audio in Unexpected Language
+Guidance for troubleshooting a number of problems is linked from [Common Problems](../Support/CommonProblems.md).
+This covers topics related to:
+- Configuration/hardware of the computer that QGC is running on - e.g. [Audio Problems](../Support/audio_problems.md) and [UI rendering/OpenGL driver problems](../Support/ui_driver_problems.md)
+- Interacting with a vehicle - e.g. [Parameter Download](../Support/ParameterDownload.md) and [Plan Upload/Download](../Support/PlanUploadDownload.md) failures.
 
-On Windows 64-bit machines *QGroundControl* may sometimes play audio/messages in a language that does not match the *Text-to-speech* setting in **Control Panel > Speech** (e.g. audio spoken in German on an English machine).
-
-This can occur because 64-bit Windows only displays 64-bit voices, while *QGroundControl* is a 32-bit application (on Windows) and hence can only run 32-bit voices.
-
-The solution is to set the desired *32-bit voice* for your system:
-1. Run the control panel application: **C:\Windows\SysWOW64\Speech\SpeechUX\sapi.cpl**.
-2. Make your desired *Voice selection* and then click **OK** at the bottom of the dialog.
-   ![Windows 32-bit Text-To-Speech Control Panel](../../assets/support/windows_text_to_speech.png)
-
-> **Note** Additional information about the Windows speech APIs can be found [here](https://www.webbie.org.uk/blog/microsoft-speech/).
-
-
-### Windows: UI Rendering/Video Driver Issues {#opengl_troubleshooting}
-
-If you experience UI rendering issues or video driver crashes on Windows, this may be caused by "flaky" OpenGL drivers. *QGroundControl* provides 3 shortcuts that you can use to start *QGroundControl* in "safer" video modes (try these in order):
-
-- **QGroundControl:** QGC uses OpenGL graphics drivers directly.
-- **GPU Compatibility Mode:** QGC uses ANGLE drivers, which implement OpenGL on top of DirectX.
-- **GPU Safe Mode:** QGC uses a software rasterizer for the UI (this is very slow).
 
 ## Help Improve these Docs!
 
 Just like *QGroundControl* itself, the user guide is an open source, user created and supported GitBook. We welcome [Pull Requests](https://github.com/mavlink/qgc-user-guide/pulls) against the guide for fixes and/or updates.
-

--- a/en/Support/audio_problems.md
+++ b/en/Support/audio_problems.md
@@ -1,0 +1,15 @@
+# Audio Problems
+
+
+## 64-bit Windows: Audio in Unexpected Language
+
+On Windows 64-bit machines *QGroundControl* may sometimes play audio/messages in a language that does not match the *Text-to-speech* setting in **Control Panel > Speech** (e.g. audio spoken in German on an English machine).
+
+This can occur because 64-bit Windows only displays 64-bit voices, while *QGroundControl* is a 32-bit application (on Windows) and hence can only run 32-bit voices.
+
+The solution is to set the desired *32-bit voice* for your system:
+1. Run the control panel application: **C:\Windows\SysWOW64\Speech\SpeechUX\sapi.cpl**.
+2. Make your desired *Voice selection* and then click **OK** at the bottom of the dialog.
+   ![Windows 32-bit Text-To-Speech Control Panel](../../assets/support/windows_text_to_speech.png)
+
+> **Note** Additional information about the Windows speech APIs can be found [here](https://www.webbie.org.uk/blog/microsoft-speech/).

--- a/en/Support/ui_driver_problems.md
+++ b/en/Support/ui_driver_problems.md
@@ -1,0 +1,9 @@
+# UI Rendering/Driver Problems
+
+## Windows: UI Rendering/Video Driver Issues {#opengl_troubleshooting}
+
+If you experience UI rendering issues or video driver crashes on Windows, this may be caused by "flaky" OpenGL drivers. *QGroundControl* provides 3 shortcuts that you can use to start *QGroundControl* in "safer" video modes (try these in order):
+
+- **QGroundControl:** QGC uses OpenGL graphics drivers directly.
+- **GPU Compatibility Mode:** QGC uses ANGLE drivers, which implement OpenGL on top of DirectX.
+- **GPU Safe Mode:** QGC uses a software rasterizer for the UI (this is very slow).

--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -11,7 +11,7 @@ Install *QGroundControl* for Windows Vista or later:
 
 > **Note** The Windows installer creates 3 shortcuts: **QGroundControl**, **GPU Compatibility Mode**, **GPU Safe Mode**. 
   Use the first shortcut unless you experience startup or video rendering issues. 
-  For more information see [Support > Troubleshooting](../Support/Support.md#opengl_troubleshooting).
+  For more information see [UI Rendering/Driver Problems](../Support/ui_driver_problems.md#opengl_troubleshooting).
 
 
 ## Mac OS X


### PR DESCRIPTION
This moves existing troubleshooting topics (open gl rendering, audio in wrong language) into the common problems and links all of them from the Support page. 

I leave you to decide if you want to merge this because it is arguable and **you might not want to**

Benefit is that all topics related to using QGC are grouped, and all are linked from the support page. That means it is a one-stop-shop for problems. 

Downside is that the troubleshooting topics are quite different character - they are about bad computer hardware or config rather than using the app. They are also things you will discover before you have done anything with QGC. So it feels like we've pushed them down one extra level and perhaps made them harder to find.

Not sure. My leaning was not, but figure I'd done the work and leave to you to decide.