### PR TITLE
Installer: Add info about removing the modemmanager

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -32,14 +32,25 @@ Install *QGroundControl* for Mac OS X 10.8 or later:
   
 ## Ubuntu Linux
 
+Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
+Before installing *QGroundControl* you should remove it and grant yourself permissions to access the serial port:
+1. On the command prompt enter:
+   ```sh
+   sudo usermod -a -G dialout $USER
+   sudo apt-get remove modemmanager
+   ```
+1. Logout and login again to enable the change to user permissions.
+   
 Install *QGroundControl* for Ubuntu Linux 16.04 LTS or later:
-
 1. Download [QGroundControl.AppImage](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.AppImage).
-1. Install using the terminal commands:
+1. Install (and run) using the terminal commands:
    ```sh
    chmod +x ./QGroundControl.AppImage
    ./QGroundControl.AppImage  (or double click)
    ```
+   
+
+
 
 ## Android
 


### PR DESCRIPTION
This originates from posts like http://discuss.px4.io/t/ubuntu-users-how-do-you-even-launch-qgc/9907

@DonLakeFlyer I assume this needs to be done by everyone working on Ubuntu, so it should appear first in the section as I have done, rather than as a note afterwards (ie. "If you run into this problem...")