### PR TITLE
Setup: Add instructions to install GStreamer in Ubuntu

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -40,7 +40,10 @@ Install *QGroundControl* for Ubuntu Linux 16.04 LTS or later:
    chmod +x ./QGroundControl.AppImage
    ./QGroundControl.AppImage  (or double click)
    ```
-
+1. For video support, you need to install GStreamer:
+```sh
+    sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav
+   ```
 ## Android
 
 Install *QGroundControl* for Android 5.1 or later:


### PR DESCRIPTION
This adds instructions to install Gstreamer components required to see video streams.
Without it QGC is unable to create the gstreamer nodes and fails with `VideoReceiver::start() failed. Error with gst_element_factory_make(‘avdec_h264’)`