### PR TITLE
Tidy Motor Setup

### DIFF
--- a/en/SetupView/Motors.md
+++ b/en/SetupView/Motors.md
@@ -9,7 +9,6 @@ Motor Setup is used to test individual motors/servos (for example, to verify tha
 
 ## Test Steps
 
-
 To test the motors:
 
 1. Remove all propellers.
@@ -19,12 +18,6 @@ To test the motors:
 1. Adjust the individual sliders to spin the motors and confirm they spin in the correct direction.
    > **Note** The motors only spin after you release the slider and will automatically stop spinning after 3 seconds.
 
-## PX4 Notes
+## Additional Information
 
-The following notes apply PX4 only:
-- A safety switch (if used) must be be pressed before motor testing is allowed.
-- The kill-switch will immediately stop motors.
-- The parameter [COM_MOT_TEST_EN](http://docs.px4.io/master/en/advanced_config/parameter_reference.html#COM_MOT_TEST_EN) disables motor testing.
-- Pixhawk boards with an IO are only tested for motors/servos connected to MAIN pins.
-
-Additional information on motor testing can be found in: [Basic Configuration > Motor Setup](http://docs.px4.io/master/en/config/motors.html) (PX4 User Guide).
+- [Basic Configuration > Motor Setup](http://docs.px4.io/master/en/config/motors.html) (*PX4 User Guide*) - This contains additional PX4-specific information.

--- a/en/SetupView/Motors.md
+++ b/en/SetupView/Motors.md
@@ -1,23 +1,30 @@
 # Motors Setup
 
-This section is used to setup and test individual motors/servos, and applies to both ArduPilot and PX4:
+Motor Setup is used to test individual motors/servos (for example, to verify that motors spin in the correct direction).
 
-1. Remove all propellers before running the test.
-   > **Warning** You must do this before activating the motors (next step)
-1. Slide the switch to enable motor sliders (labeled "Propellers are removed - Enable motor sliders").
-1. Adjust the individual sliders to spin the motors and confirm they spin in the correct direction.
-   > **Note** The motors only spin after you release the slider and will automatically stop spinning after 3 seconds.
-
-<!-- PX4 Firmware specific:
-- If a safety button is used, it must be pressed before motor testing is allowed.
-- The kill-switch still works to stop motors immediately.
-- The parameter `COM_MOT_TEST_EN` can be used to completely disable motor testing.
-- On boards with an IO, only the MAIN pins can be tested.
-- On the shell, `motor_test` can be used as well, which has additional options.
--->
+> **Tip** These instructions apply to PX4 and to most vehicle types on ArduPilot.
+  Vehicle-specific instructions are provided as sub-topics (e.g. [Motors Setup (ArduSub)](../SetupView/Motors_ardusub.md)).
 
 ![Motors Test](../../assets/setup/Motors.png)
 
-Vehicle specific instructions are provided in the following topics:
-* [Motors Setup (ArduSub)](../SetupView/Motors_ardusub.md)
+## Test Steps
 
+
+To test the motors:
+
+1. Remove all propellers.
+   > **Warning** You must remove props before activating the motors!
+1. (*PX4-only*) Enable safety switch - if used.
+1. Slide the switch to enable motor sliders (labeled: *Propellers are removed - Enable motor sliders*).
+1. Adjust the individual sliders to spin the motors and confirm they spin in the correct direction.
+   > **Note** The motors only spin after you release the slider and will automatically stop spinning after 3 seconds.
+
+## PX4 Notes
+
+The following notes apply PX4 only:
+- A safety switch (if used) must be be pressed before motor testing is allowed.
+- The kill-switch will immediately stop motors.
+- The parameter [COM_MOT_TEST_EN](http://docs.px4.io/master/en/advanced_config/parameter_reference.html#COM_MOT_TEST_EN) disables motor testing.
+- Pixhawk boards with an IO are only tested for motors/servos connected to MAIN pins.
+
+Additional information on motor testing can be found in: [Basic Configuration > Motor Setup](http://docs.px4.io/master/en/config/motors.html) (PX4 User Guide).


### PR DESCRIPTION
This follows on from #226 

I added one specific note about the safety switch in the instructions.

The rest I added in a PX4 Notes section, except the one on the motor testing in console, which is not relevant to QGC users particularly. 

I did it this way so instructions "just work" for most setups, but the "more" special cases are still covered (e.g. knowing about the enable param). 