### PR TITLE
Joystick: Remove 16-button limit text

### DIFF
--- a/en/SetupView/Joystick.md
+++ b/en/SetupView/Joystick.md
@@ -33,8 +33,6 @@ To configure a joystick:
 1. Press the **Calibrate** button and then follow the on-screen instructions to calibrate/move the sticks.
 1. Test the buttons and sticks work as intended by pressing them, and viewing the result in the Axis/Button monitor.
 1. Select the flight modes/vehicle functions activated by each joystick button.
-   A maximum of 16 joystick *button actions* can be set. 
-   <!-- MANUAL_CONTROL used to send button values only has 16 bits -->
 1. Check the **Enable joystick input** checkbox to begin sending joystick commands to the vehicle.
 
 


### PR DESCRIPTION
This removes line that states max of 16 joystick *button actions* can be set. This was a misinterpretation of the fact that `MANUAL_CONTROL` only has 16 bits for setting the on-off status of buttons. However QGC is itself not limited by this message, and Autopilots generally speaking do not need to use this for knowing what action to preform.