### PR TITLE
LANGS-Move to korean crowdin

### DIFF
--- a/LANGS.md
+++ b/LANGS.md
@@ -1,2 +1,2 @@
 * [English](en/)
-* [Korean (한국어)](kr/)
+* [Korean (한국어)](ko/)


### PR DESCRIPTION
We've been keeping the pre-Crowdin korean translation, but with recent changes it comes harder to keep in sync. I've switched to the crowdin version.
The kr version is still in tree to aid translation.