### PR TITLE
download/install - clarify use Ubuntu 18.04

### DIFF
--- a/en/Support/troubleshooting_qgc.md
+++ b/en/Support/troubleshooting_qgc.md
@@ -68,3 +68,16 @@ LIBVA_DRIVER_NAME=fakedriver ./QGroundControl)  will this make the
 ```
 
 Other alternatives are to disable one of the VGAs, uninstall VA API components, or upgrade to GStreamer 1.16 (there is no easy way to do this on Ubuntu 18.04 - please contribute a recipe if you find one!)
+
+## Ubuntu 16.04: GLIBC_2.27 not found {#glibc_2_27}
+
+QGroundControl 4.0 and later require Ubuntu 18.04 LTS (or later).
+They do not run on Ubuntu 16.04.
+
+If you try you will get the error as shown:
+```sh
+$ ./QGroundControl.AppImage 
+/tmp/.mount_i4hPuB/QGroundControl: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /tmp/.mount_i4hPuB/QGroundControl)
+```
+ 
+ If you need to use Ubuntu 16.04 then one workaround is to build from source without the video libraries.

--- a/en/Support/troubleshooting_qgc.md
+++ b/en/Support/troubleshooting_qgc.md
@@ -71,7 +71,7 @@ Other alternatives are to disable one of the VGAs, uninstall VA API components, 
 
 ## Ubuntu 16.04: GLIBC_2.27 not found {#glibc_2_27}
 
-QGroundControl 4.0 and later require Ubuntu 18.04 LTS (or later).
+The pre-built AppImages for QGroundControl 4.0 (and later) can only run on Ubuntu 18.04 LTS (or later).
 They do not run on Ubuntu 16.04.
 
 If you try you will get the error as shown:

--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -66,8 +66,8 @@ To install *QGroundControl*:
 > **Note** There are known [video steaming issues](../Support/troubleshooting_qgc.md#dual_vga) on Ubuntu 18.04 systems with dual adaptors.
 
 <span></span>
-> **Note** *QGroundControl* versions prior to 4.0 can run on Ubuntu 16.04.
-  To run later versions on Ubuntu 16.04 [build from source without video libraries](https://dev.qgroundcontrol.com/en/getting_started/).
+> **Note** Prebuilt *QGroundControl* versions from 4.0 cannot run on Ubuntu 16.04.
+  To run these versions on Ubuntu 16.04 you can [build QGroundControl from source without video libraries](https://dev.qgroundcontrol.com/en/getting_started/).
 
 
 ## Android {#android}

--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -14,7 +14,7 @@ For the best experience and compatibility, we recommend you the newest version o
 
 ## Windows {#windows}
 
-Install *QGroundControl* for Windows Vista or later:
+*QGroundControl* can be installed on Windows Vista or later:
 
 1. Download [QGroundControl-installer.exe](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl-installer.exe).
 1. Double click the executable to launch the installer.
@@ -26,7 +26,7 @@ Install *QGroundControl* for Windows Vista or later:
 
 ## Mac OS X {#macOS}
 
-Install *QGroundControl* for macOS 10.10 or later: 
+*QGroundControl* can be installed on macOS 10.10 or later: 
 
 1. Download [QGroundControl.dmg](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.dmg).
 1. Double-click the .dmg file to mount it, then drag the *QGroundControl* application to your *Application* folder.
@@ -38,6 +38,8 @@ Install *QGroundControl* for macOS 10.10 or later:
 
   
 ## Ubuntu Linux {#ubuntu}
+
+*QGroundControl* can be installed/run on Ubuntu LTS 18.04 (and later).
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 Before installing *QGroundControl* you should remove the modem manager and grant yourself permissions to access the serial port.
@@ -53,7 +55,7 @@ Before installing *QGroundControl* for the first time:
 1. Logout and login again to enable the change to user permissions.
 
 &nbsp;
-To install *QGroundControl* for Ubuntu Linux 16.04 LTS or later:
+To install *QGroundControl*:
 1. Download [QGroundControl.AppImage](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.AppImage).
 1. Install (and run) using the terminal commands:
    ```sh
@@ -62,6 +64,10 @@ To install *QGroundControl* for Ubuntu Linux 16.04 LTS or later:
    ```
 
 > **Note** There are known [video steaming issues](../Support/troubleshooting_qgc.md#dual_vga) on Ubuntu 18.04 systems with dual adaptors.
+
+<span></span>
+> **Note** *QGroundControl* versions prior to 4.0 can run on Ubuntu 16.04.
+  To run later versions on Ubuntu 16.04 [build from source without video libraries](https://dev.qgroundcontrol.com/en/getting_started/).
 
 
 ## Android {#android}


### PR DESCRIPTION
This clarifies that you need Ubuntu 18.04. It does not specify the QGC version this applies to up front (we assume latest) but at the end of the section there is a note that explains how to get this working on ubuntu 16.04.