### PR TITLE
Daily Releases: Add direct links to Android APKs

### DIFF
--- a/en/releases/daily_builds.md
+++ b/en/releases/daily_builds.md
@@ -17,3 +17,5 @@ These can be downloaded from the links below (install as described in [Download 
 * [Linux](https://s3-us-west-2.amazonaws.com/qgroundcontrol/builds/master/QGroundControl.AppImage)
 * [Android](https://play.google.com/store/apps/details?id=org.mavlink.qgroundcontrolbeta) - Google Play: Listed as *QGroundControl (Daily Test Build)*.
 * iOS currently unavailable
+
+> **Note** The QGroundControl Continous Delivery pipeline from time to time might experience issues uploading to the Google Play store. You can find the daily build APK for Android devices for direct download here: [QGroundControl32.apk](https://qgroundcontrol.s3-us-west-2.amazonaws.com/builds/master/QGroundControl32.apk), and [QGroundControl64.apk](https://qgroundcontrol.s3-us-west-2.amazonaws.com/builds/master/QGroundControl64.apk)


### PR DESCRIPTION
Since our CI/CD is currently really fragile and uploading to the google play store sometimes is interrupted for long periods of time, we add direct links to circumvent this problem and give access to our community for flight testing purposes.