### PR TITLE
Ubuntu version requirement set to 18

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -42,7 +42,7 @@ For the best experience and compatibility, we recommend you the newest version o
   
 ## Ubuntu Linux {#ubuntu}
 
-*QGroundControl* can be installed/run on Ubuntu LTS 20.04 (and later).
+*QGroundControl* can be installed/run on Ubuntu LTS 18.04 (and later).
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 Before installing *QGroundControl* you should remove the modem manager and grant yourself permissions to access the serial port.


### PR DESCRIPTION
Roll back change, the update to 20.04 was done prematurely and had the unintended consequence of leaving our Ubuntu 18.04 users behind