### PR TITLE
Downloads: move downloads from S3 to CloudFront

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -16,7 +16,7 @@ For the best experience and compatibility, we recommend you the newest version o
 
 *QGroundControl* can be installed on 64 bit versions of Windows:
 
-1. Download [QGroundControl-installer.exe](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl-installer.exe).
+1. Download [QGroundControl-installer.exe](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer.exe).
 1. Double click the executable to launch the installer.
 
 > **Note** The Windows installer creates 3 shortcuts: **QGroundControl**, **GPU Compatibility Mode**, **GPU Safe Mode**. 
@@ -31,7 +31,7 @@ For the best experience and compatibility, we recommend you the newest version o
 
 *QGroundControl* can be installed on macOS 10.20 or later: 
 
-1. Download [QGroundControl.dmg](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.dmg).
+1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 1. Double-click the .dmg file to mount it, then drag the *QGroundControl* application to your *Application* folder.
 
   > **Note** QGroundControl continues to not be signed which causes problem on Catalina. To open QGC app for the first time:
@@ -59,7 +59,7 @@ Before installing *QGroundControl* for the first time:
 
 &nbsp;
 To install *QGroundControl*:
-1. Download [QGroundControl.AppImage](https://s3-us-west-2.amazonaws.com/qgroundcontrol/latest/QGroundControl.AppImage).
+1. Download [QGroundControl.AppImage](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage).
 1. Install (and run) using the terminal commands:
    ```sh
    chmod +x ./QGroundControl.AppImage

--- a/en/releases/daily_builds.md
+++ b/en/releases/daily_builds.md
@@ -7,15 +7,15 @@ Daily Builds of *QGroundControl* have the absolute latest set of [new features](
 
 These can be downloaded from the links below (install as described in [Download and Install](../getting_started/download_and_install.md)):
 
-* [Windows](https://s3-us-west-2.amazonaws.com/qgroundcontrol/builds/master/QGroundControl-installer.exe)
-* [OS X](https://s3-us-west-2.amazonaws.com/qgroundcontrol/builds/master/QGroundControl.dmg)
+* [Windows](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer.exe)
+* [OS X](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg)
   > **Note** QGroundControl continues to not be signed which causes problem on Catalina. To open QGC app for the first time:
 
   > *   Right-click the QGC app icon, select Open from the menu. You will only be presented with an option to Cancel. Select Cancel.
   > *   Right-click the QGC app icon again, Open from the menu. This time you will be presented with the option to Open.
 
-* [Linux](https://s3-us-west-2.amazonaws.com/qgroundcontrol/builds/master/QGroundControl.AppImage)
+* [Linux](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.AppImage)
 * [Android](https://play.google.com/store/apps/details?id=org.mavlink.qgroundcontrolbeta) - Google Play: Listed as *QGroundControl (Daily Test Build)*.
 * iOS currently unavailable
 
-> **Note** The QGroundControl Continous Delivery pipeline from time to time might experience issues uploading to the Google Play store. You can find the daily build APK for Android devices for direct download here: [QGroundControl32.apk](https://qgroundcontrol.s3-us-west-2.amazonaws.com/builds/master/QGroundControl32.apk), and [QGroundControl64.apk](https://qgroundcontrol.s3-us-west-2.amazonaws.com/builds/master/QGroundControl64.apk)
+> **Note** The QGroundControl Continous Delivery pipeline from time to time might experience issues uploading to the Google Play store. You can find the daily build APK for Android devices for direct download here: [QGroundControl32.apk](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl32.apk), and [QGroundControl64.apk](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl64.apk)


### PR DESCRIPTION
AWS S3 transfer out costs is too high. We are moving to a CDN approach,
we will keep an eye on caching policies to make sure dailies are not
too aggressively cached, and allow for new installers to be available
daily.

NOTE: In case anyone bumps into 404's downloading the daily android APK's, they are not being built right now and are not available on S3

cc @dagar 