### PR TITLE
Add missing xcb install

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -53,7 +53,7 @@ Before installing *QGroundControl* for the first time:
    ```sh
    sudo usermod -a -G dialout $USER
    sudo apt-get remove modemmanager -y
-   sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
+   sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl libxcb-xinerama0 -y
    ```
 1. Logout and login again to enable the change to user permissions.
 


### PR DESCRIPTION
I freshly installed Ubuntu LTS 20.4 and followed the `Download and Install` instructions. The app image failed to run because I was missing the libxcb-xinerama0 package. The solution to the error was not immediately obvious and many Ubuntu users will likely face the same problem unless the `Download and install` instructions have the user install the missing package.

Here is the original error I got.

```sh
sam@hp:~/Downloads$ ./QGroundControl.AppImage 
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, xcb.

Aborted (core dumped)
```