### PR TITLE
Removes multi-channel flight mode support

### DIFF
--- a/en/SetupView/FlightModes.md
+++ b/en/SetupView/FlightModes.md
@@ -42,15 +42,9 @@ All values are automatically saved as they are changed.
 
 
 
-## PX4 Pro Flight Mode Setup
+## PX4 Autopilot Flight Mode Setup
 
-*PX4* (*QGroundControl*) supports two modes for mapping flight modes to transmitter switches/dials:
-
-- **Single Channel Mode Selection:** Assign up to 6 flight modes to switch positions encoded in a single channel. 
-- **Multi Channel Mode Selection:** Assign modes to switch positions encoded in one or more channels. Some modes are hard coded to share channels, or are defined/set automatically based on other mode selections (the behaviour of multi-channel mode selection can sometimes be confusing). 
-
-> **Tip** The recommended approach is to use *Single Channel Mode Selection* because it is easy to understand and configure. It is similar to the approach used by ArduPilot. 
-
+*PX4* (*QGroundControl*) supports assigning up to 6 flight modes to switch positions encoded in a single channel.
 
 ### Single-Channel Mode {#single_channel}
 
@@ -64,8 +58,6 @@ To configure single-channel flight mode selection:
 1. Select the **Gear** icon (Vehicle Setup) in the top toolbar and then **Flight Modes** in the sidebar.
    
    ![Flight modes multi-channel](../../assets/setup/flight_modes_single_channel_px4.jpg)
-   
-   > **Tip** If the screen opens in *Multi Channel Mode* click the **Use Single Channel Mode Selection** button to change screen.
    
 1. Specify *Flight Mode Settings*:
    * Select the **Mode channel** (above this shown as Channel 5, but this will depend on your transmitter configuration). 
@@ -90,33 +82,3 @@ The video then shows how to use *QGroundControl* to specify the mode channel and
 {% youtube %}
 http://www.youtube.com/watch?v=scqO7vbH2jo
 {% endyoutube %}
-
-### Multi-Channel Mode
-
-> **Tip** We recommend you use [Single Channel Flight Mode](#single_channel) selection because the Multi Channel selection user interface can be confusing. If you do choose to use this method, then the best approach is to start assigning channels and take note of information displayed by *QGroundControl* following your selection. 
-
-The multi-channel selection UI allows you to map one or more modes to one or more channels. There are some modes (and hence switches) that must always be defined, and the channel to which they must be allocated.
-
-To configure flight modes using the multi-channel UI:
-
-1. Turn on your RC transmitter.
-1. Select the **Gear** icon (Vehicle Setup) in the top toolbar and then **Flight Modes** in the sidebar.
-   
-   ![Flight modes multi-channel](../../assets/setup/flight_modes_multi_channel_px4.jpg)
-   
-   > **Tip** If the screen opens in *Single Channel Mode* click the **Use Multi Channel Mode Selection** button to change screen.
-   
-1. Select the modes you want to assign to your switches and select the associated channel (selected modes will *move* in the UI to be grouped by channel).
-   There are a number of complications on the mode to channel assignments:
-   * Some modes will have a grayed out channel selector because they cannot be disabled and you cannot directly set the value. For example:
-     * *Mission* mode - Has the same channel number as *Hold* (if it is defined), or otherwise the same channel as *Stabilized/Main* mode.
-     * *Altitude* mode - Has the same channel number as *Position Control* (if it is defined), or otherwise the same channel as *Stabilized/Main* mode.
-   * *Assist* mode -  This mode is added to the same channel as *Stabilized/Main* mode if (and only if) *Position Control* is enabled and defined on a different channel than *Stabilized/Main*.
-1. Click the **Generate Thresholds** button. 
-   * This will automatically create threshold values for all modes, spread evenly across each channel for its assigned modes. For example, in the mode assignment shown above, most modes are assigned to mode 5, and you can see that the channel thresholds for each mode are spread evenly across the channel. 
-
-This mode is demonstrated in the [PX4 setup video @6m53s](https://youtu.be/91VGmdSlbo4?t=6m53s) (youtube).
-
-> **Note** This flight mode selection mechanism is relatively complicated due to the way that PX4 works out which mode should be selected. You may be able to gain some insight from this [flow chart](https://dev.px4.io/en/concept/flight_modes.html#flight-mode-evaluation-diagram) (PX4 Developer Guide).
-
-


### PR DESCRIPTION
The Advanced Flight Modes UI view was removed from QGC in https://github.com/mavlink/qgroundcontrol/pull/10193

Starting with v1.13 PX4 no longer supports this feature