### PR TITLE
Add note about fixed wing autotuning not being supported

### DIFF
--- a/en/SetupView/tuning_px4.md
+++ b/en/SetupView/tuning_px4.md
@@ -17,6 +17,9 @@ Auto-tuning automates the process of tuning the PX4 rate and attitude controller
 > **Note** This guide shows the default usage of this feature.
 > Additional information and configuration can be found in the [PX4 Autotuning Guide](http://docs.px4.io/master/en/config/autotune.html) (PX4 User Guide).
 
+<span></span>
+> **Note** The QGroundControl Autotuning UI is not enabled for Fixed wing vehicles - see [qgroundcontrol#10194](https://github.com/mavlink/qgroundcontrol/issues/10194) (though it is for VTOL vehicles in fixed wing flight).
+> You can start Fixed-wing autotuning by setting the parameter [FW_AT_START](../advanced_config/parameter_reference.md#FW_AT_START).
 
 ### Pre-Autotuning Test
 
@@ -29,7 +32,7 @@ To make sure the vehicle is stable enough for auto-tuning:
 1. Perform a normal preflight safety checklist to ensure the flight zone is clear and has enough space.
 1. Takeoff and prepare for the test
    - **Multicopters:** Take off and hover at 1m above ground in **Altitude mode** or Stabilized mode.
-   - **Fixed-wing:** Take off and fly at cruise speed in **Position mode** or **Altitude mode**.
+   - **Fixed-wing mode:** Take off and fly at cruise speed in **Position mode** or **Altitude mode**.
 1. Use the RC transmitter roll stick to perform the following maneuver, tilting the vehicle just a few degrees: _roll left > roll right > center_ (The whole maneuver should take about 3 seconds).
    The vehicle should stabilise itself within 2 oscillations.
 1. Repeat the maneuver, tilting with larger amplitudes at each attempt.
@@ -56,7 +59,7 @@ The test steps are:
 1. Takeoff using RC control and prepare for test:
    - **Multicopters:** Takeoff using the remote controller in **Altitude mode**.
      Hover the vehicle at a safe distance and at a few meters above ground (between 4 and 20m).
-   - **Fixed-wing:** Once flying at cruise speed, activate **Hold Mode**.
+   - **VTOL in Fixed-wing mode:** Once flying at cruise speed, activate **Hold Mode**.
       This will guide the plane to fly in circle at constant altitude and speed.
 1. In QGroundControl, open the menu: **Vehicle setup > PID Tuning**
 


### PR DESCRIPTION
Related to https://github.com/PX4/PX4-user_guide/pull/1800 and https://github.com/mavlink/qgroundcontrol/issues/10194

We should remove this when the QGC bug is fixed