### PR TITLE
getting_started: download and install: fix MacOS incorrect version

### DIFF
--- a/en/getting_started/download_and_install.md
+++ b/en/getting_started/download_and_install.md
@@ -29,7 +29,7 @@ For the best experience and compatibility, we recommend you the newest version o
 
 ## Mac OS X {#macOS}
 
-*QGroundControl* can be installed on macOS 10.20 or later: 
+*QGroundControl* can be installed on macOS 11.20 or later: 
 
 1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 1. Double-click the .dmg file to mount it, then drag the *QGroundControl* application to your *Application* folder.


### PR DESCRIPTION
10.20 never existed, and [the previous specified version was 10.10](https://github.com/mavlink/qgc-user-guide/pull/278/files), so presumably the major number was just forgotten in the update.

Brought up in [this forum comment](https://discuss.bluerobotics.com/t/suspected-networking-error-macbook-pro-to-raspberry-pie-3b/11829/4).