### PR TITLE
Autotuning PX4 now works for plane

### DIFF
--- a/en/SetupView/tuning_px4.md
+++ b/en/SetupView/tuning_px4.md
@@ -17,10 +17,6 @@ Auto-tuning automates the process of tuning the PX4 rate and attitude controller
 > **Note** This guide shows the default usage of this feature.
 > Additional information and configuration can be found in the [PX4 Autotuning Guide](http://docs.px4.io/master/en/config/autotune.html) (PX4 User Guide).
 
-<span></span>
-> **Note** The QGroundControl Autotuning UI is not enabled for Fixed wing vehicles - see [qgroundcontrol#10194](https://github.com/mavlink/qgroundcontrol/issues/10194) (though it is for VTOL vehicles in fixed wing flight).
-> You can start Fixed-wing autotuning by setting the parameter [FW_AT_START](../advanced_config/parameter_reference.md#FW_AT_START).
-
 ### Pre-Autotuning Test
 
 Auto-tuning is performed while flying.


### PR DESCRIPTION
This replaces #372 which fixed the wrong translation tree.